### PR TITLE
Fix: index build failures (URL parser, youtube-transcript-api v1, UA)

### DIFF
--- a/palav/retrieval.py
+++ b/palav/retrieval.py
@@ -105,8 +105,19 @@ def extract_youtube_video_id(url: str) -> Optional[str]:
     return m.group(1) if m else None
 
 
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/122.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+
 def fetch_html_text(url: str, timeout: int = 20) -> Tuple[str, str]:
-    r = requests.get(url, timeout=timeout, headers={"User-Agent": "Mozilla/5.0"})
+    r = requests.get(url, timeout=timeout, headers=BROWSER_HEADERS)
     r.raise_for_status()
     soup = BeautifulSoup(r.text, "html.parser")
     for tag in soup(["script", "style", "nav", "footer", "header", "noscript", "aside"]):
@@ -120,7 +131,7 @@ def fetch_html_text(url: str, timeout: int = 20) -> Tuple[str, str]:
 def fetch_pdf_text(url: str, timeout: int = 30) -> Tuple[str, str]:
     if pdfplumber is None:
         raise RuntimeError("pdfplumber is not installed.")
-    r = requests.get(url, timeout=timeout, headers={"User-Agent": "Mozilla/5.0"})
+    r = requests.get(url, timeout=timeout, headers=BROWSER_HEADERS)
     r.raise_for_status()
     title = url
     pages_text: List[str] = []
@@ -140,12 +151,25 @@ def fetch_youtube_transcript_text(url: str) -> Tuple[str, str]:
     vid = extract_youtube_video_id(url)
     if not vid:
         raise RuntimeError("Could not parse YouTube video id")
-    try:
-        transcript = YouTubeTranscriptApi.get_transcript(vid, languages=["en"])
-    except Exception:
-        transcript = YouTubeTranscriptApi.get_transcript(vid)
-    text = " ".join([x.get("text", "") for x in transcript])
-    return f"YouTube transcript: {vid}", normalize_whitespace(text)
+
+    # youtube-transcript-api v1.0 replaced the classmethod `get_transcript`
+    # with an instance method `fetch` that returns a FetchedTranscript object.
+    # Handle both so upgrades don't break the build.
+    if hasattr(YouTubeTranscriptApi, "get_transcript"):
+        try:
+            raw = YouTubeTranscriptApi.get_transcript(vid, languages=["en"])
+        except Exception:
+            raw = YouTubeTranscriptApi.get_transcript(vid)
+        segments = [x.get("text", "") for x in raw]
+    else:
+        api = YouTubeTranscriptApi()
+        try:
+            fetched = api.fetch(vid, languages=["en"])
+        except Exception:
+            fetched = api.fetch(vid)
+        segments = [getattr(s, "text", "") for s in fetched]
+
+    return f"YouTube transcript: {vid}", normalize_whitespace(" ".join(segments))
 
 
 def chunk_text(text: str, chunk_chars: int = CHUNK_CHARS, overlap: int = CHUNK_OVERLAP) -> List[str]:
@@ -180,6 +204,14 @@ def build_faiss_index(vectors: np.ndarray):
 
 
 def load_allowed_urls(path: str) -> List[str]:
+    """Extract URLs from the links file, one per occurrence.
+
+    Lines can contain a descriptive prefix plus one or more http(s) URLs
+    (e.g. ``"Title: https://a/b   https://c/d"``); all URLs are extracted
+    and deduplicated. Lines with no URL (section headers, orphan
+    descriptions) are skipped — the previous behavior of falling back to
+    the raw line produced bogus entries the fetcher always failed on.
+    """
     if not os.path.exists(path):
         return []
     urls: List[str] = []
@@ -189,7 +221,7 @@ def load_allowed_urls(path: str) -> List[str]:
             if not line or line.startswith("#"):
                 continue
             found = re.findall(r"https?://\S+", line)
-            urls.extend(found if found else [line])
+            urls.extend(found)
     return list(dict.fromkeys(urls))
 
 

--- a/tests/unit/test_retrieval.py
+++ b/tests/unit/test_retrieval.py
@@ -46,6 +46,25 @@ def test_load_allowed_urls_filters_comments_and_blanks(tmp_path):
     assert urls == ["https://example.com/a", "https://example.com/b"]
 
 
+def test_load_allowed_urls_drops_non_url_lines_and_extracts_multiple(tmp_path):
+    p = tmp_path / "links.txt"
+    p.write_text(
+        "SECTION HEADER:\n"
+        "Title text with no URL\n"
+        "Description: https://example.com/one\n"
+        "Two links on one line: https://example.com/two https://example.com/three\n"
+        "FAQ's\n"
+        "POSTPARTUM SUPPORT workbook\n",
+        encoding="utf-8",
+    )
+    urls = load_allowed_urls(str(p))
+    assert urls == [
+        "https://example.com/one",
+        "https://example.com/two",
+        "https://example.com/three",
+    ]
+
+
 def test_index_key_changes_with_file_contents(tmp_path):
     p = tmp_path / "links.txt"
     p.write_text("https://a", encoding="utf-8")


### PR DESCRIPTION
## Context
First production deploy hit the 20% index-build failure threshold with 28/62 sources failing (45%). Three separable causes — none are new regressions, all were masked before because the old Streamlit app silently accepted a degraded index on startup.

Replaces #20 (dirty due to residual pre-squash commits on the old branch).

## Fixes

### 1. URL parser dropped non-URL lines (~15 of 28 failures)
`load_allowed_urls` used to fall back to the raw line when no URL was present, which turned section headers into fake URLs the fetcher always 400/schema-failed on:
```
FAILED: HOW TO VIDEOS: -> InvalidSchema("No connection adapters were found ...")
FAILED: POSTPARTUM SUPPORT  workbook -> MissingSchema("Invalid URL ...")
FAILED: FAQ's -> InvalidURL("Failed to parse: FAQ's")
... (15 more)
```
Now the parser skips any line with no `http(s)://` match.

### 2. `youtube-transcript-api` v1.0 API change (1 failure)
`YouTubeTranscriptApi.get_transcript` was removed in the v1 upgrade. `fetch_youtube_transcript_text` now detects both APIs (`get_transcript` classmethod vs `fetch` instance method) so upgrades don't break future builds.

### 3. Realistic browser User-Agent (reduces 403s)
Hopkins, MotherToBaby, UNICEF UK, Bronson Health, etc. 403 on the bare `Mozilla/5.0` UA. Swapped to a full desktop-Chrome UA + `Accept` + `Accept-Language` headers. Not a silver bullet — sites with Cloudflare challenge pages will still fail — but picks up the low-hanging ones.

## Test
Added `test_load_allowed_urls_drops_non_url_lines_and_extracts_multiple` covering the new skip behavior.

```
22 passed (was 21), 3 consecutive runs deterministic
```

## Expected post-merge behavior
After the URL parser fix the denominator drops from 62 to ~47 real URLs. Net effect on the deploy pipeline:
- ~15 fake-URL failures → gone
- 1 YouTube failure → gone
- Some subset of the 6 `403`s should now succeed
- A handful of genuine dead URLs remain (CDC moved page, truncated `nxedge.io` URL) — failure ratio should comfortably be under the 20% threshold. If not, we'll clean up `palav_url_links.txt` next.

## Test plan
- [x] `pytest tests/unit tests/integration -q` → 22 passed.
- [ ] CI green on this PR.
- [ ] After merge, first `deploy.yml` run reports `Index ready` exit code 0 (no threshold trip).
- [ ] `sam deploy` proceeds; stack outputs populate.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8