### PR TITLE
Parallel test/prod deploys via GitHub Environments + external Cognito

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,22 +6,40 @@ on:
   schedule:
     # Weekly index refresh: Sunday 05:00 UTC (~midnight US Eastern).
     # Educational/medical sources rarely change, so weekly is plenty.
+    # Scheduled + push runs always target `test`; promoting to `prod`
+    # is an explicit workflow_dispatch action.
     - cron: "0 5 * * 0"
   workflow_dispatch:
+    inputs:
+      target:
+        description: Deployment target environment
+        type: choice
+        options: [test, prod]
+        default: test
 
 permissions:
   id-token: write
   contents: read
 
-env:
-  AWS_REGION: us-east-1
-  STACK_NAME: palavbot
-  ECR_REPOSITORY: palavbot
-  OPENAI_KEY_PARAM: /palavbot/openai_api_key
+concurrency:
+  group: deploy-${{ github.event.inputs.target || 'test' }}
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Reads env-scoped variables/secrets from this GitHub Environment.
+    # Configure two environments (Settings -> Environments): `test`, `prod`.
+    # Add "Required reviewers" to `prod` to gate promotions behind approval.
+    environment: ${{ github.event.inputs.target || 'test' }}
+    env:
+      AWS_REGION: us-east-1
+      TARGET: ${{ github.event.inputs.target || 'test' }}
+      # One stack + ECR repo + SSM key path per environment, so test and
+      # prod run in full isolation with distinct ApiUrls.
+      STACK_NAME: palavbot-${{ github.event.inputs.target || 'test' }}
+      ECR_REPOSITORY: palavbot-${{ github.event.inputs.target || 'test' }}
+      OPENAI_KEY_PARAM: /palavbot/${{ github.event.inputs.target || 'test' }}/openai_api_key
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +56,16 @@ jobs:
 
       - name: Run pytest (unit + integration)
         run: pytest tests/unit tests/integration -q
+
+      - name: Preflight - required environment variables
+        run: |
+          : "${{ vars.PALAV_COGNITO_USER_POOL_ID:?must be set in the '${{ env.TARGET }}' GitHub Environment}}"
+          : "${{ vars.PALAV_COGNITO_AUDIENCES:?must be set in the '${{ env.TARGET }}' GitHub Environment (comma-separated app client IDs)}}"
+          echo "Target:          $TARGET"
+          echo "Stack:           $STACK_NAME"
+          echo "ECR repo:        $ECR_REPOSITORY"
+          echo "OpenAI SSM path: $OPENAI_KEY_PARAM"
+          echo "User Pool:       ${{ vars.PALAV_COGNITO_USER_POOL_ID }}"
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -92,9 +120,12 @@ jobs:
             --no-fail-on-empty-changeset \
             --image-repositories "PalavbotFunction=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}" \
             --parameter-overrides \
+              StackName=$STACK_NAME \
               ImageUri=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }} \
               CorsOrigin=${{ vars.PALAV_CORS_ORIGIN || '*' }} \
-              OpenAIKeyParamName=${{ env.OPENAI_KEY_PARAM }}
+              OpenAIKeyParamName=$OPENAI_KEY_PARAM \
+              CognitoUserPoolId=${{ vars.PALAV_COGNITO_USER_POOL_ID }} \
+              CognitoAudiences=${{ vars.PALAV_COGNITO_AUDIENCES }}
 
       - name: Read stack outputs
         id: outputs
@@ -102,8 +133,12 @@ jobs:
           aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
             --query "Stacks[0].Outputs" --output json > outputs.json
           echo "PALAV_API_URL=$(jq -r '.[] | select(.OutputKey=="ApiUrl").OutputValue' outputs.json)" >> "$GITHUB_ENV"
-          echo "PALAV_USER_POOL_ID=$(jq -r '.[] | select(.OutputKey=="UserPoolId").OutputValue' outputs.json)" >> "$GITHUB_ENV"
-          echo "PALAV_CLIENT_ID=$(jq -r '.[] | select(.OutputKey=="UserPoolClientId").OutputValue' outputs.json)" >> "$GITHUB_ENV"
+          # Cognito is externally managed; smoke tests read pool + client from env-scoped repo variables.
+          echo "PALAV_USER_POOL_ID=${{ vars.PALAV_COGNITO_USER_POOL_ID }}" >> "$GITHUB_ENV"
+          echo "PALAV_CLIENT_ID=$(echo '${{ vars.PALAV_COGNITO_AUDIENCES }}' | cut -d, -f1)" >> "$GITHUB_ENV"
+          echo ""
+          echo "Deployment summary:"
+          cat outputs.json | jq '.'
 
       - name: Post-deploy smoke tests
         env:

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Palavbot backend - Lambda container behind HTTP API, Cognito JWT auth.
+Description: Palavbot backend - Lambda container behind HTTP API, validating JWTs from an externally-managed Cognito User Pool.
 
 Parameters:
   StackName:
@@ -20,6 +20,18 @@ Parameters:
   LogRetentionDays:
     Type: Number
     Default: 7
+  CognitoUserPoolId:
+    Type: String
+    Description: >
+      ID of the externally-managed Cognito User Pool whose JWTs the API trusts
+      (e.g. us-east-1_XXXXXXXXX). This stack does NOT create or own the pool.
+    AllowedPattern: "^[a-z0-9-]+_[A-Za-z0-9]+$"
+  CognitoAudiences:
+    Type: CommaDelimitedList
+    Description: >
+      Comma-separated list of Cognito App Client IDs (audiences) whose ID
+      tokens the API accepts. Typically one per app client that will be
+      issuing JWTs forwarded to palavbot.
 
 Globals:
   Function:
@@ -29,39 +41,6 @@ Globals:
     Tracing: Active
 
 Resources:
-  UserPool:
-    Type: AWS::Cognito::UserPool
-    Properties:
-      UserPoolName: !Sub ${StackName}-users
-      AutoVerifiedAttributes: [email]
-      UsernameAttributes: [email]
-      Policies:
-        PasswordPolicy:
-          MinimumLength: 12
-          RequireUppercase: true
-          RequireLowercase: true
-          RequireNumbers: true
-          RequireSymbols: false
-
-  UserPoolClient:
-    Type: AWS::Cognito::UserPoolClient
-    Properties:
-      UserPoolId: !Ref UserPool
-      ClientName: !Sub ${StackName}-frontend
-      GenerateSecret: false
-      ExplicitAuthFlows:
-        - ALLOW_USER_PASSWORD_AUTH
-        - ALLOW_USER_SRP_AUTH
-        - ALLOW_REFRESH_TOKEN_AUTH
-      PreventUserExistenceErrors: ENABLED
-      AccessTokenValidity: 60
-      IdTokenValidity: 60
-      RefreshTokenValidity: 30
-      TokenValidityUnits:
-        AccessToken: minutes
-        IdToken: minutes
-        RefreshToken: days
-
   PalavbotFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -122,17 +101,15 @@ Resources:
           CognitoJwt:
             IdentitySource: $request.header.Authorization
             JwtConfiguration:
-              issuer: !Sub https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}
-              audience:
-                - !Ref UserPoolClient
+              issuer: !Sub https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}
+              audience: !Ref CognitoAudiences
 
 Outputs:
   ApiUrl:
     Description: Base URL for the HTTP API.
     Value: !Sub https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com
-  UserPoolId:
-    Value: !Ref UserPool
-  UserPoolClientId:
-    Value: !Ref UserPoolClient
   FunctionName:
     Value: !Ref PalavbotFunction
+  TrustedUserPoolId:
+    Description: Cognito User Pool whose JWTs this deployment trusts (external; not owned by this stack).
+    Value: !Ref CognitoUserPoolId


### PR DESCRIPTION
## What this does

Replaces the single `palavbot` stack with two isolated, simultaneously-running deployments — `palavbot-test` and `palavbot-prod` — each with its own API URL, ECR repo, SSM OpenAI key, CloudWatch log group, and trusted Cognito pool. Both alive at once, fully independent.

**Trigger matrix:**
| Event | Target |
|---|---|
| Push to `main` | `test` (auto) |
| Weekly cron (Sun 05:00 UTC) | `test` (auto; refreshes index) |
| `workflow_dispatch` → target `test` | `test` |
| `workflow_dispatch` → target `prod` | `prod` (manual only, gated by Required Reviewers if configured) |

Automated triggers can never hit prod by design.

## Architecture

```
                        GitHub Actions
                             │
                   target = test | prod
                             │
     ┌───────────────────────┼───────────────────────┐
     │                       │                       │
     ▼                       ▼                       ▼
 environment:           environment:             environment:
   "test"                 "prod"                   (shared)
 vars scoped to test     vars scoped to prod       secrets
                             │
      ┌──────────────────────┼──────────────────────┐
      ▼                      ▼                      ▼
  palavbot-test         palavbot-prod         ECR: palavbot-{env}
  CFN stack             CFN stack             SSM: /palavbot/{env}/openai_api_key
  trusts test pool      trusts prod pool      Logs: /aws/lambda/palavbot-{env}-api
  own ApiUrl            own ApiUrl
```

## Code changes

### `template.yaml`
- **Remove** `UserPool` + `UserPoolClient` — identity is now external.
- **Add** `CognitoUserPoolId` (`AllowedPattern` validates format) and `CognitoAudiences` (`CommaDelimitedList` — multi-client support baked in).
- Authorizer wires directly to those params.
- Outputs drop `UserPoolId` / `UserPoolClientId`; add `TrustedUserPoolId` so operators can verify at a glance which pool each stack trusts.

### `.github/workflows/deploy.yml`
- `workflow_dispatch.inputs.target: choice [test, prod]`, default `test`.
- `job.environment: ${{ inputs.target || 'test' }}` — reads that GitHub Environment's scoped variables + secrets.
- `env.STACK_NAME`, `env.ECR_REPOSITORY`, `env.OPENAI_KEY_PARAM` all suffixed with `-${target}` so isolation is total.
- `concurrency.group: deploy-${target}` prevents overlapping deploys to the same env; test and prod can still deploy in parallel.
- Preflight step fails fast with a readable error when required env vars are missing and prints a summary (target / stack / pool) at the top of every run.
- Smoke-test pool/client sourced from env-scoped variables.

## Setup required before first merge

You'll configure everything through the GitHub + AWS UIs. Three self-contained checklist issues filed:

- **#25** — Create `test` and `prod` GitHub Environments, populate scoped variables, add Required Reviewers on `prod`.
- **#26** — Create per-env SSM SecureString parameters (`/palavbot/test/openai_api_key` and `/palavbot/prod/openai_api_key`).

And one cleanup task for **after** the first successful test deploy:
- **#27** — Delete the legacy `palavbot` stack / old SSM param / old ECR repo once `palavbot-test` is serving.

Once #25 and #26 are done, push/merge triggers auto-deploy to `test`; prod is on demand.

## After merge

1. `main` pushes and weekly cron → `palavbot-test` stack updates.
2. Validate test endpoint end-to-end.
3. When ready: Actions → Deploy → **Run workflow** → choose `prod` → (approval prompt if configured) → `palavbot-prod` stack deploys/updates.
4. Both URLs remain live independently.
5. Run #27 cleanup.

## Test plan
- [x] `pytest tests/unit tests/integration -q` → 22 passed.
- [ ] CI green on this PR.
- [ ] #25 and #26 complete.
- [ ] Merge → first auto-deploy lands on `palavbot-test` only. `describe-stacks --stack-name palavbot-prod` returns no-such-stack until a manual dispatch.
- [ ] Manual dispatch to `prod` → `palavbot-prod` stack created; `TrustedUserPoolId` output = `us-east-1_0rlksWAIX`.
- [ ] Test JWT fails on prod endpoint (`401`); prod JWT fails on test endpoint (`401`) — authorizer isolation confirmed.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8