### PR TITLE
Use single shared SSM parameter for the OpenAI key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,9 @@ jobs:
       # prod run in full isolation with distinct ApiUrls.
       STACK_NAME: palavbot-${{ github.event.inputs.target || 'test' }}
       ECR_REPOSITORY: palavbot-${{ github.event.inputs.target || 'test' }}
-      OPENAI_KEY_PARAM: /palavbot/${{ github.event.inputs.target || 'test' }}/openai_api_key
+      # Single shared OpenAI key across environments — intentional.
+      # Per-env split would be /palavbot/{target}/openai_api_key.
+      OPENAI_KEY_PARAM: /palavbot/openai_api_key
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What
Both test and prod deploys now read `/palavbot/openai_api_key` (the existing SSM parameter) instead of per-env paths. No need to create `/palavbot/test/...` + `/palavbot/prod/...`.

One-line change in `deploy.yml`:

```diff
- OPENAI_KEY_PARAM: /palavbot/${{ github.event.inputs.target || 'test' }}/openai_api_key
+ OPENAI_KEY_PARAM: /palavbot/openai_api_key
```

## Trade-off
Can't rotate the test key independently of prod. If that matters later, flip the line back and create the two per-env parameters.

## Effect on #26
Supersedes it. The existing `/palavbot/openai_api_key` is all we need. Will close #26 on merge.

## Test plan
- [x] `pytest tests/unit tests/integration` → 22 passed.
- [ ] CI green.
- [ ] After merge, `deploy.yml` run succeeds at the "Fetch OpenAI key" step reading the existing parameter.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8