### PR TITLE
Fix: preflight step YAML parse error blocking all deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,14 +60,17 @@ jobs:
         run: pytest tests/unit tests/integration -q
 
       - name: Preflight - required environment variables
+        env:
+          PALAV_COGNITO_USER_POOL_ID: ${{ vars.PALAV_COGNITO_USER_POOL_ID }}
+          PALAV_COGNITO_AUDIENCES: ${{ vars.PALAV_COGNITO_AUDIENCES }}
         run: |
-          : "${{ vars.PALAV_COGNITO_USER_POOL_ID:?must be set in the '${{ env.TARGET }}' GitHub Environment}}"
-          : "${{ vars.PALAV_COGNITO_AUDIENCES:?must be set in the '${{ env.TARGET }}' GitHub Environment (comma-separated app client IDs)}}"
+          : "${PALAV_COGNITO_USER_POOL_ID:?must be set in the '$TARGET' GitHub Environment}"
+          : "${PALAV_COGNITO_AUDIENCES:?must be set in the '$TARGET' GitHub Environment (comma-separated app client IDs)}"
           echo "Target:          $TARGET"
           echo "Stack:           $STACK_NAME"
           echo "ECR repo:        $ECR_REPOSITORY"
           echo "OpenAI SSM path: $OPENAI_KEY_PARAM"
-          echo "User Pool:       ${{ vars.PALAV_COGNITO_USER_POOL_ID }}"
+          echo "User Pool:       $PALAV_COGNITO_USER_POOL_ID"
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## What
Fix a YAML parse error that prevented `deploy.yml` from being queued at all:

```
Invalid Argument - failed to parse workflow:
(Line: 63, Col: 14): Unexpected symbol: 'PALAV_COGNITO_USER_POOL_ID:?must'.
Located at position 6 within expression:
vars.PALAV_COGNITO_USER_POOL_ID:?must be set in the '${{ env.TARGET }}' GitHub Environment
```

## Root cause
My preflight step mixed two different syntaxes:
- `${VAR:?err}` — bash parameter expansion, runs at *shell* time.
- `${{ ... }}` — GitHub Actions expression, evaluated at *parse* time.

I nested the bash form inside the Actions one, and the Actions parser saw `:?` as a bogus expression operator.

## Fix
Move the fail-if-empty check into plain bash. Inject the variable values through `env:` on the step, then let the shell handle `:?`:

```yaml
- name: Preflight - required environment variables
  env:
    PALAV_COGNITO_USER_POOL_ID: ${{ vars.PALAV_COGNITO_USER_POOL_ID }}
    PALAV_COGNITO_AUDIENCES: ${{ vars.PALAV_COGNITO_AUDIENCES }}
  run: |
    : "${PALAV_COGNITO_USER_POOL_ID:?must be set in the '$TARGET' GitHub Environment}"
    : "${PALAV_COGNITO_AUDIENCES:?must be set in the '$TARGET' GitHub Environment (comma-separated app client IDs)}"
```

Same behavior (missing variable → step fails fast with the expected message), but this one actually parses.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` succeeds locally.
- [ ] CI passes on this PR.
- [ ] After merge, `Actions → Deploy → Run workflow → target: test` queues successfully.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8