### PR TITLE
Fix: use $default stage so FastAPI routes are actually reachable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -89,7 +89,11 @@ Resources:
   HttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
-      StageName: prod
+      # Use the $default stage so invoke URLs have no stage prefix
+      # (https://<id>.execute-api.../chat, not .../prod/chat). A named
+      # stage causes the prefix to leak through the Lambda Web Adapter
+      # into FastAPI's routing, which then 404s every request.
+      StageName: $default
       CorsConfiguration:
         AllowOrigins: [!Ref CorsOrigin]
         AllowHeaders: [authorization, content-type]


### PR DESCRIPTION
## The bug
Every request to the deployed API was returning 404. Proven by direct curl against the test stack:

```
curl .../healthz           → 404 {"message":"Not Found"}           ← API Gateway, no matching stage
curl .../prod/healthz      → 404 {"detail":"Not Found"}, server: uvicorn  ← FastAPI, wrong path
```

The second response is the giveaway: the Lambda is being reached, but FastAPI sees the path as `/prod/healthz`, not `/healthz`. Its routes (`@app.get("/healthz")`, `@app.post("/chat")`) don't match, so it 404s every request.

## Root cause
My template sets `StageName: prod`, which creates a named API Gateway stage. Named stages prefix invoke URLs with the stage name (`.../prod/...`). API Gateway v2 passes the full `rawPath` (including `/prod`) into the Lambda event, and AWS Lambda Web Adapter forwards it verbatim to uvicorn — so FastAPI sees `/prod/healthz` instead of `/healthz`.

## Fix
Switch to `StageName: $default`. The `$default` stage has no path prefix, so the invoke URL matches the path FastAPI sees. Matches what:
- the integration doc documents (`<ApiUrl>/chat`)
- the consumer already has in Secrets Manager (`https://oua4f7reme.execute-api.us-east-1.amazonaws.com`, no `/prod`)

## After merge
- `deploy.yml` fires, updates `palavbot-test`. The stage gets replaced (brief downtime on test — none on prod since prod hasn't been deployed yet).
- `curl .../healthz` returns 200.
- `curl -X POST .../chat` with a Cognito ID token returns the expected JSON.
- No frontend or Secrets Manager change needed.

## Why I didn't catch this sooner
My smoke test was gated on `PALAV_TEST_USER`/`PASSWORD` secrets, which you deferred. With those set it would have hit `/chat` against the real API and failed immediately on the 404 — exactly the class of bug a post-deploy smoke is meant to catch. Following up I should probably unconditionally hit `/healthz` as a minimal post-deploy check (it needs no auth). Filed mental note; can do it in a follow-up.

## Test plan
- [x] `pytest tests/unit tests/integration` → 22 passed.
- [x] Direct curl reproduction of the 404 (both URL shapes).
- [ ] CI green on this PR.
- [ ] After merge + redeploy: `curl <ApiUrl>/healthz` → 200.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8