### PR TITLE
Chore: API Gateway access logs, Lambda memory bump, healthz smoke check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,6 +145,24 @@ jobs:
           echo "Deployment summary:"
           cat outputs.json | jq '.'
 
+      - name: Post-deploy healthz check
+        # Unauthenticated liveness probe. Runs unconditionally — needs no
+        # Cognito credentials, so it's always the first thing to catch a
+        # deploy that went green but is serving 404/500. Retries to
+        # absorb cold-start latency.
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -sSfo /tmp/healthz.json --max-time 20 "$PALAV_API_URL/healthz"; then
+              echo "healthz OK on attempt $i:"
+              jq '.' /tmp/healthz.json
+              exit 0
+            fi
+            echo "healthz attempt $i failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "healthz failed after 5 attempts against $PALAV_API_URL"
+          exit 1
+
       - name: Post-deploy smoke tests
         env:
           PALAV_TEST_USER: ${{ secrets.PALAV_TEST_USER }}

--- a/template.yaml
+++ b/template.yaml
@@ -36,7 +36,10 @@ Parameters:
 Globals:
   Function:
     Timeout: 30
-    MemorySize: 1024
+    # 2048 MB (2 vCPU) — the 1024 MB baseline hit the 10s Lambda init
+    # budget during cold starts (observed 9.89s of 10s). More memory
+    # also buys more CPU, which roughly halves cold-start time.
+    MemorySize: 2048
     Architectures: [arm64]
     Tracing: Active
 
@@ -86,6 +89,12 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${StackName}-api
       RetentionInDays: !Ref LogRetentionDays
 
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${StackName}
+      RetentionInDays: !Ref LogRetentionDays
+
   HttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
@@ -94,6 +103,13 @@ Resources:
       # stage causes the prefix to leak through the Lambda Web Adapter
       # into FastAPI's routing, which then 404s every request.
       StageName: $default
+      AccessLogSettings:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        # JSON format makes CloudWatch Logs Insights queries trivial.
+        # Includes authorizer error/claims so JWT auth failures are visible —
+        # otherwise 401s never reach Lambda and are effectively invisible.
+        Format: >-
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","path":"$context.path","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","responseLatency":"$context.responseLatency","integrationLatency":"$context.integrationLatency","integrationStatus":"$context.integrationStatus","authorizerError":"$context.authorizer.error","userSub":"$context.authorizer.claims.sub","userAud":"$context.authorizer.claims.aud"}
       CorsConfiguration:
         AllowOrigins: [!Ref CorsOrigin]
         AllowHeaders: [authorization, content-type]


### PR DESCRIPTION
## Three small hardening changes

Observations from the first production deploy drove these:
- The `StageName: prod` bug 404'd every request for hours before I noticed. Two of the three changes below would have caught it immediately.
- Cold-start init hit 9.89s of the 10s Lambda budget; razor thin.
- Auth failures (401/403) never reach Lambda, so they were invisible in CloudWatch.

### 1. API Gateway access logs
New `ApiAccessLogGroup` CloudWatch log group (7-day retention, per stack). JSON format written for every request with:

- `requestId`, `ip`, `routeKey`, `path`, `httpMethod`, `status`
- `responseLatency`, `integrationLatency`, `integrationStatus`
- `authorizerError`, `userSub`, `userAud` — surfaces Cognito JWT failures that never reach Lambda

Queryable from CloudWatch Logs Insights in one field.

### 2. Lambda memory 1024 → 2048 MB
Doubles allocated CPU; roughly halves cold start. Cost delta ~$0.84/mo at 10k req/mo. Worth every penny given the observed 9.89/10s init time.

### 3. Unconditional `/healthz` smoke check
New step in `deploy.yml` after `Read stack outputs`, before the existing pytest smoke:

```yaml
- name: Post-deploy healthz check
  run: |
    for i in 1 2 3 4 5; do
      curl -sSfo /tmp/healthz.json --max-time 20 "$PALAV_API_URL/healthz" && exit 0
      sleep 5
    done
    exit 1
```

No auth needed, runs on every deploy, fails the workflow loudly if routes aren't wired up right.

## Test plan
- [x] `pytest tests/unit tests/integration` → 22 passed.
- [x] `deploy.yml` YAML parses.
- [ ] CI green.
- [ ] After merge: `deploy.yml` runs, Post-deploy healthz step prints `healthz OK on attempt 1` and the JSON body.
- [ ] CloudWatch → `/aws/apigateway/palavbot-test` log group exists and receives entries for subsequent requests.
- [ ] `palavbot-test` Lambda configuration shows 2048 MB memory.

https://claude.ai/code/session_01TsHP9JXY78Yro98aq6mug8